### PR TITLE
fix: catch TypeError when currentState is None and add Sentry context

### DIFF
--- a/app.py
+++ b/app.py
@@ -348,7 +348,12 @@ def set_temp(temp: float, *, skip_override_detection: bool = False) -> None:
     try:
         for attempt in tenacity.Retrying(
             retry=tenacity.retry_if_exception_type(
-                (requests.exceptions.RequestException, KeyError, SpaOfflineError)
+                (
+                    requests.exceptions.RequestException,
+                    KeyError,
+                    TypeError,
+                    SpaOfflineError,
+                )
             ),
             wait=tenacity.wait_random_exponential(multiplier=1, max=60),
             stop=tenacity.stop_after_attempt(5),
@@ -357,6 +362,13 @@ def set_temp(temp: float, *, skip_override_detection: bool = False) -> None:
             with attempt:
                 api = controlmyspa.ControlMySpa(
                     os.getenv("CONTROLMYSPA_USER"), os.getenv("CONTROLMYSPA_PASS")
+                )
+                info = getattr(api, "_info", None)  # pylint: disable=protected-access
+                sentry_sdk.set_context(
+                    "controlmyspa_info",
+                    {"info_keys": list(info.keys())}
+                    if isinstance(info, dict)
+                    else {"info": repr(info)},
                 )
                 pool = {
                     "desired_temp": api.desired_temp,
@@ -447,7 +459,12 @@ def status() -> str:
         try:
             for attempt in tenacity.Retrying(
                 retry=tenacity.retry_if_exception_type(
-                    (requests.exceptions.RequestException, KeyError, SpaOfflineError)
+                    (
+                        requests.exceptions.RequestException,
+                        KeyError,
+                        TypeError,
+                        SpaOfflineError,
+                    )
                 ),
                 wait=tenacity.wait_random_exponential(multiplier=1, max=60),
                 stop=tenacity.stop_after_attempt(5),


### PR DESCRIPTION
## Summary
- Adds `TypeError` to tenacity retry exception types in `set_temp()` and `status()`
- Adds Sentry context (`controlmyspa_info`) with spa info keys for debugging API responses
- Handles the case where ControlMySpa API returns `currentState: null` (not just missing)

## Context
Follow-up to #211. CONTROLMYSPA-PORSSARI-1E showed the API can return `currentState: null`, causing `TypeError: 'NoneType' object is not subscriptable` which wasn't retried. Also fixed upstream in controlmyspa 4.0.1 (`self._info.get("currentState")` check).

## Test plan
- [ ] All 63 tests pass
- [ ] ruff + pylint clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)