### PR TITLE
chore: update controlmyspa to 4.0.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -160,14 +160,14 @@ wheels = [
 
 [[package]]
 name = "controlmyspa"
-version = "4.0.1"
+version = "4.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/fd/4cfa5706a533e3d9798bc6c483ca5a3d60c6e245c7b83e80a3d8e8eeee00/controlmyspa-4.0.1.tar.gz", hash = "sha256:59e98fa8a219803090b74daceae16f3cd03d17550daaa810271c63101bc34ee4", size = 17600, upload-time = "2026-05-05T09:25:25.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/30/c6ce7f8621fbda80de174a6ad831ca49f304ac09765a5c6244ca77c81d1b/controlmyspa-4.0.2.tar.gz", hash = "sha256:c7d4f0d0aaaa6bc292192a097a751d993ab232bb7e4eb0cc5346ca76bce7b214", size = 17740, upload-time = "2026-05-07T07:23:31.096Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b5/ca6ef1dad14f239a0b5c556f669b248d905b632aecbc4a2acf3593ceae15/controlmyspa-4.0.1-py3-none-any.whl", hash = "sha256:961a185d1bf7716ed0386318890e823b7356230b6b524099c5afaa4b24102780", size = 8531, upload-time = "2026-05-05T09:25:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/03/4f58156ef9db1bf51fc53338e77b217e429c684e7a99d39410e9684c5196/controlmyspa-4.0.2-py3-none-any.whl", hash = "sha256:d33f0ef350b34ab1a04d6fe3143bdddcabced1f977263084096330185c174505", size = 8529, upload-time = "2026-05-07T07:23:29.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Updates `controlmyspa` from 4.0.1 to 4.0.2
- 4.0.2 fixes handling of `currentState: null` (not just missing key) when the spa gateway is offline

## Test plan
- [ ] All 63 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)