### PR TITLE
Increase stale-temperature alert timeouts (heating 2h→3h, idle 8h→12h)

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,7 +91,7 @@ def check_stale_temperature() -> None:
     # Determine if we're in heating mode
     latest = history[-1]
     heating = latest["desired_temp"] >= temp_high > latest["current_temp"]
-    stale_minutes = 180 if heating else 480  # 3h heating, 8h idle
+    stale_minutes = 180 if heating else 720  # 3h heating, 12h idle
 
     # Find readings within the stale window using actual timestamps
     now = datetime.datetime.now(tz=datetime.UTC)

--- a/app.py
+++ b/app.py
@@ -91,7 +91,7 @@ def check_stale_temperature() -> None:
     # Determine if we're in heating mode
     latest = history[-1]
     heating = latest["desired_temp"] >= temp_high > latest["current_temp"]
-    stale_minutes = 120 if heating else 480  # 2h heating, 8h idle
+    stale_minutes = 180 if heating else 480  # 3h heating, 8h idle
 
     # Find readings within the stale window using actual timestamps
     now = datetime.datetime.now(tz=datetime.UTC)

--- a/test_app.py
+++ b/test_app.py
@@ -629,10 +629,10 @@ class TestTelegram:
     )
     @patch("app.send_telegram")
     def test_stale_alert_heating_mode(self, mock_tg):
-        """Alert after 2h of identical readings when heating."""
+        """Alert after 3h of identical readings when heating."""
         now = datetime.datetime.now(tz=datetime.UTC)
-        for i in range(9):
-            t = now - datetime.timedelta(minutes=121 - i * 15)
+        for i in range(13):
+            t = now - datetime.timedelta(minutes=181 - i * 15)
             app_module.temperature_history.append(
                 {"time": t.isoformat(), "current_temp": 30.0, "desired_temp": 37}
             )
@@ -732,7 +732,7 @@ class TestTelegram:
         app_module.STALE_ALERT_ACTIVE = True
         now = datetime.datetime.now(tz=datetime.UTC)
         for i in range(10):
-            t = now - datetime.timedelta(minutes=130 - i * 14)
+            t = now - datetime.timedelta(minutes=190 - i * 20)
             app_module.temperature_history.append(
                 {
                     "time": t.isoformat(),
@@ -790,7 +790,7 @@ class TestTelegram:
     def test_no_false_stale_alert_after_restart_heating(self, mock_tg):
         """No stale alert when app just restarted with insufficient history.
 
-        In heating mode, needs 2h of data. With only 3 readings over 20min,
+        In heating mode, needs 3h of data. With only 3 readings over 20min,
         should not alert.
         """
         now = datetime.datetime.now(tz=datetime.UTC)

--- a/test_app.py
+++ b/test_app.py
@@ -647,10 +647,10 @@ class TestTelegram:
     )
     @patch("app.send_telegram")
     def test_stale_alert_general_mode(self, mock_tg):
-        """Alert after 8h of identical readings in general mode."""
+        """Alert after 12h of identical readings in general mode."""
         now = datetime.datetime.now(tz=datetime.UTC)
-        for i in range(36):
-            t = now - datetime.timedelta(minutes=481 - i * 14)
+        for i in range(37):
+            t = now - datetime.timedelta(minutes=721 - i * 20)
             app_module.temperature_history.append(
                 {"time": t.isoformat(), "current_temp": 30.0, "desired_temp": 10}
             )
@@ -709,8 +709,8 @@ class TestTelegram:
             tz=datetime.UTC
         ) - datetime.timedelta(hours=9)
         now = datetime.datetime.now(tz=datetime.UTC)
-        for i in range(36):
-            t = now - datetime.timedelta(minutes=481 - i * 14)
+        for i in range(37):
+            t = now - datetime.timedelta(minutes=721 - i * 20)
             app_module.temperature_history.append(
                 {"time": t.isoformat(), "current_temp": 30.0, "desired_temp": 10}
             )


### PR DESCRIPTION
## Summary

The "Spa temperature stuck … Gateway may be offline" Telegram alert was firing too eagerly, producing false alarms:

- **Heating mode**: alerted after just **2h** of unchanged readings, but spas can legitimately take longer than that to show measurable movement.
- **Idle mode**: alerted after **8h**, where stable temperatures are expected and the gateway is usually fine.

This PR lengthens both stale-detection windows in `check_stale_temperature()`:

| Mode | Before | After |
|------|--------|-------|
| Heating | 2h | **3h** |
| Idle | 8h | **12h** |

```python
stale_minutes = 180 if heating else 720  # 3h heating, 12h idle
```

The 8h re-alert suppression interval (how often a still-stuck alert repeats) is unchanged.

## Testing

- Updated the affected tests so their reading windows cover the new thresholds.
- `ruff check` + `ruff format --check`: clean
- `pylint`: clean
- `pytest`: all 63 tests pass

https://claude.ai/code/session_01CbG7ZesZnrrkVBtYtBghYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbG7ZesZnrrkVBtYtBghYr)_